### PR TITLE
issue #38 (fixed logic with keybinds)

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,14 +38,15 @@ async def main():
     while running:
         for event in pygame.event.get():
 
-            keybinds.process_event(event)
-
             if event.type == pygame.QUIT:
                 running = False
             if event.type == pygame.KEYDOWN:
                 # Toggle pause with P key
                 if event.key == pygame.K_p:
-                    paused = not paused
+                    paused = not paused # always will work
+                elif not paused:
+                    keybinds.process_event(event) #blocked while paused
+                    #... other game inputs
                 
                 # Ctrl + E to jump to game over screen (testing shortcut)
                 if event.key == pygame.K_e and pygame.key.get_mods() & pygame.KMOD_CTRL:


### PR DESCRIPTION
## Description
Move `keybinds.process_event(event)` inside an `elif not paused` block so keyboard input is ignored while the game is paused.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Removed the unconditional `keybinds.process_event(event)` call at the top of the event loop
- Moved it inside the `KEYDOWN` block, under `elif not paused`, so it only fires when the game is running
- P key remains outside the `elif` so it can still toggle pause/unpause

## Testing
- [ ] I have tested these changes locally
- [ ] I have tested these changes via a browser

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
- [ ] I requested someone else to review this PR

## Related Issues
Closes #

## Additional Notes
The root cause was that `keybinds.process_event` was being called before any pause check, so key presses always fired through to the keybind manager regardless of game state. This also implicitly fixes the same issue for any other game inputs added in the future, since they'll naturally fall under the same `elif not paused` guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Input commands are now properly blocked while the application is paused, preventing unintended actions during pause mode. Commands resume processing when unpaused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->